### PR TITLE
Add America/Chicago to PYTZ_TO_MS_MAP

### DIFF
--- a/exchangelib/ewsdatetime.py
+++ b/exchangelib/ewsdatetime.py
@@ -126,6 +126,7 @@ class EWSTimeZone(object):
     PYTZ_TO_MS_MAP = {
         'UTC': 'UTC',
         'GMT': 'GMT Standard Time',
+        'America/Chicago': 'Central Standard Time',
         'US/Pacific': 'Pacific Standard Time',
         'US/Eastern': 'Eastern Standard Time',
         'Europe/Copenhagen': 'Romance Standard Time',


### PR DESCRIPTION
Americal/Chicago is the string returned from tzlocal.get_localzone()